### PR TITLE
getInterfaces returns the ip addresses organized by network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is not a background service. When the cordova view is destroyed/terminated,
 
 ## Changelog ##
 
+#### X.X.X
+
+- getInterfaces returns the ipv4 and ipv6 addresses organized by network interface
+
 #### 1.2.1
 
 - fixed error retrieving URL query String for iOS
@@ -93,8 +97,13 @@ Returns the non-loopback IPv4 and IPv6 network interfaces.
 
 ```javascript
 wsserver.getInterfaces(function(result) {
-    console.log('ipv4', result.ipv4Addresses);
-    console.log('ipv6', result.ipv6Addresses);
+    for (var interface in result) {
+        if (result.hasOwnProperty(interface)) {
+            console.log('interface', interface);
+            console.log('ipv4', result[interface].ipv4Addresses);
+            console.log('ipv6', result[interface].ipv6Addresses);
+        }
+    }
 });
 ```
 

--- a/src/android/net/becvert/cordova/WebSocketServerPlugin.java
+++ b/src/android/net/becvert/cordova/WebSocketServerPlugin.java
@@ -1,7 +1,7 @@
 /*
  * Cordova WebSocket Server Plugin
  *
- * WebSocket Server plugin for Cordova/Phonegap 
+ * WebSocket Server plugin for Cordova/Phonegap
  * by Sylvain Brejeon
  */
 
@@ -252,25 +252,36 @@ public class WebSocketServerPlugin extends CordovaPlugin {
     // return IP4 & IP6 addresses
     public static JSONObject getInterfaces() throws JSONException, SocketException {
         JSONObject obj = new JSONObject();
-        JSONArray ipv4Addresses = new JSONArray();
-        JSONArray ipv6Addresses = new JSONArray();
+        JSONObject intfobj;
+        JSONArray ipv4Addresses;
+        JSONArray ipv6Addresses;
 
         List<NetworkInterface> intfs = Collections.list(NetworkInterface.getNetworkInterfaces());
         for (NetworkInterface intf : intfs) {
-            List<InetAddress> addrs = Collections.list(intf.getInetAddresses());
-            for (InetAddress addr : addrs) {
-                if (!addr.isLoopbackAddress()) {
-                    if (addr instanceof Inet6Address) {
-                        ipv6Addresses.put(addr.getHostAddress());
-                    } else if (addr instanceof Inet4Address) {
-                        ipv4Addresses.put(addr.getHostAddress());
+            if (!intf.isLoopback()) {
+                intfobj = new JSONObject();
+                ipv4Addresses = new JSONArray();
+                ipv6Addresses = new JSONArray();
+
+                List<InetAddress> addrs = Collections.list(intf.getInetAddresses());
+                for (InetAddress addr : addrs) {
+                    if (!addr.isLoopbackAddress()) {
+                        if (addr instanceof Inet6Address) {
+                            ipv6Addresses.put(addr.getHostAddress());
+                        } else if (addr instanceof Inet4Address) {
+                            ipv4Addresses.put(addr.getHostAddress());
+                        }
                     }
+                }
+
+                if ((ipv4Addresses.length() > 0) || (ipv6Addresses.length() > 0)) {
+                    intfobj.put("ipv4Addresses", ipv4Addresses);
+                    intfobj.put("ipv6Addresses", ipv6Addresses);
+                    obj.put(intf.getName(), intfobj);
                 }
             }
         }
 
-        obj.put("ipv4Addresses", ipv4Addresses);
-        obj.put("ipv6Addresses", ipv6Addresses);
         return obj;
     }
 

--- a/src/ios/WebSocketServer.swift
+++ b/src/ios/WebSocketServer.swift
@@ -1,14 +1,14 @@
 /*
  * Cordova WebSocket Server Plugin
  *
- * WebSocket Server plugin for Cordova/Phonegap 
+ * WebSocket Server plugin for Cordova/Phonegap
  * by Sylvain Brejeon
  */
- 
+
 import Foundation
 
 @objc(WebSocketServer) public class WebSocketServer : CDVPlugin, PSWebSocketServerDelegate {
-    
+
     fileprivate var wsserver: PSWebSocketServer?
     fileprivate var port: Int?
     fileprivate var origins: [String]?
@@ -17,13 +17,13 @@ import Foundation
     fileprivate var socketsUUID: [PSWebSocket: String]!
     fileprivate var remoteAddresses: [PSWebSocket: String]!
     fileprivate var listenerCallbackId: String?
-    
+
     override public func pluginInitialize() {
         UUIDSockets  = [:]
         socketsUUID = [:]
         remoteAddresses = [:]
     }
-    
+
     override public func onAppTerminate() {
         if let server = wsserver {
             server.stop()
@@ -33,102 +33,118 @@ import Foundation
             remoteAddresses.removeAll()
         }
     }
-    
+
     public func getInterfaces(_ command: CDVInvokedUrlCommand) {
-        
+
         commandDelegate?.run(inBackground: {
-        
-            var ipv4Addresses: [String] = []
-            var ipv6Addresses: [String] = []
-        
+
+            var obj = [String: [String: [String]]]()
+            var intfobj: [String: [String]]
+            var ipv4Addresses: [String]
+            var ipv6Addresses: [String]
+
             for intf in Interface.allInterfaces() {
                 if !intf.isLoopback {
+                    if let ifobj = obj[intf.name] {
+                        intfobj = ifobj
+                        ipv4Addresses = intfobj["ipv4Addresses"]!
+                        ipv6Addresses = intfobj["ipv6Addresses"]!
+                    } else {
+                        intfobj = [:]
+                        ipv4Addresses = []
+                        ipv6Addresses = []
+                    }
+
                     if intf.family == .ipv6 {
-                        ipv6Addresses.append(intf.address!)
+                        if ipv6Addresses.index(of: intf.address!) == nil {
+                            ipv6Addresses.append(intf.address!)
+                        }
                     } else if intf.family == .ipv4 {
-                        ipv4Addresses.append(intf.address!)
+                        if ipv4Addresses.index(of: intf.address!) == nil {
+                            ipv4Addresses.append(intf.address!)
+                        }
+                    }
+
+                    if (!ipv4Addresses.isEmpty) || (!ipv6Addresses.isEmpty) {
+                        intfobj["ipv4Addresses"] = ipv4Addresses
+                        intfobj["ipv6Addresses"] = ipv6Addresses
+                        obj[intf.name] = intfobj
                     }
                 }
             }
-            
-            if ipv6Addresses.count > 1 {
-                ipv6Addresses = Array(Set(ipv6Addresses))
-            }
-        
-            let addresses: NSDictionary = NSDictionary(objects: [ipv4Addresses, ipv6Addresses], forKeys: ["ipv4Addresses" as NSCopying, "ipv6Addresses" as NSCopying])
-            
+
             #if DEBUG
-                print("WebSocketServer: getInterfaces: \(addresses)")
+                print("WebSocketServer: getInterfaces: \(obj)")
             #endif
-            
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: addresses as! [AnyHashable: Any])
+
+            let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: obj)
             pluginResult?.setKeepCallbackAs(false)
             self.commandDelegate?.send(pluginResult, callbackId: command.callbackId)
-            
+
         })
-        
+
     }
-    
+
     public func start(_ command: CDVInvokedUrlCommand) {
-        
+
         #if DEBUG
             print("WebSocketServer: start")
         #endif
-        
+
         if wsserver != nil {
             return
         }
-        
+
         port = command.argument(at: 0) as? Int
         origins = command.argument(at: 1) as? [String]
         protocols = command.argument(at: 2) as? [String]
-        
+
         if let server = PSWebSocketServer(host: nil, port: UInt(port!)) {
             listenerCallbackId = command.callbackId
             wsserver = server
             server.delegate = self
-            
+
             commandDelegate?.run(inBackground: {
                 server.start()
             })
-            
+
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
             pluginResult?.setKeepCallbackAs(true)
         }
-        
+
     }
-    
+
     public func stop(_ command: CDVInvokedUrlCommand) {
-        
+
         #if DEBUG
             print("WebSocketServer: stop")
         #endif
-        
+
         if let server = wsserver {
-            
+
             commandDelegate?.run(inBackground: {
                 server.stop()
             })
-        
+
         }
     }
-    
+
     public func send(_ command: CDVInvokedUrlCommand) {
-        
+
         #if DEBUG
             print("WebSocketServer: send")
         #endif
-        
+
         let uuid = command.argument(at: 0) as? String
         let msg = command.argument(at: 1) as? String
-        
+
         if uuid != nil && msg != nil {
             if let webSocket = UUIDSockets[uuid!] {
-                
+
                 commandDelegate?.run(inBackground: {
                     webSocket.send(msg)
                 })
-                
+
             } else {
                 #if DEBUG
                     print("WebSocketServer: Send: unknown socket.")
@@ -140,20 +156,20 @@ import Foundation
             #endif
         }
     }
-    
+
     public func close(_ command: CDVInvokedUrlCommand) {
-        
+
         #if DEBUG
             print("WebSocketServer: close")
         #endif
-        
+
         let uuid = command.argument(at: 0) as? String
         let code = command.argument(at: 1, withDefault: -1) as! Int
         let reason = command.argument(at: 2) as? String
-        
+
         if uuid != nil {
             if let webSocket = UUIDSockets[uuid!] {
-                
+
                 commandDelegate?.run(inBackground: {
                     if (code == -1) {
                         webSocket.close()
@@ -161,7 +177,7 @@ import Foundation
                         webSocket.close(withCode: code, reason: reason)
                     }
                 })
-                
+
             } else {
                 #if DEBUG
                     print("WebSocketServer: Close: unknown socket.")
@@ -173,59 +189,59 @@ import Foundation
             #endif
         }
     }
-    
+
     public func serverDidStart(_ server: PSWebSocketServer!) {
-        
+
         #if DEBUG
             print("WebSocketServer: Server did start…")
         #endif
-        
+
         let status: NSDictionary = NSDictionary(objects: ["onStart", "0.0.0.0", Int(server.realPort)], forKeys: ["action" as NSCopying, "addr" as NSCopying, "port" as NSCopying])
         let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: status as! [AnyHashable: Any])
         pluginResult?.setKeepCallbackAs(true)
         commandDelegate?.send(pluginResult, callbackId: listenerCallbackId)
     }
-    
+
     public func serverDidStop(_ server: PSWebSocketServer!) {
-        
+
         #if DEBUG
             print("WebSocketServer: Server did stop…")
         #endif
-        
+
         wsserver = nil
         UUIDSockets.removeAll()
         socketsUUID.removeAll()
         remoteAddresses.removeAll()
-        
+
         let status: NSDictionary = NSDictionary(objects: ["onStop", "0.0.0.0", Int(server.realPort)], forKeys: ["action" as NSCopying, "addr" as NSCopying, "port" as NSCopying])
         let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: status as! [AnyHashable: Any])
         pluginResult?.setKeepCallbackAs(false)
         commandDelegate?.send(pluginResult, callbackId: listenerCallbackId)
     }
-    
+
     public func server(_ server: PSWebSocketServer!, didFailWithError error: Error!) {
-        
+
         #if DEBUG
             print("WebSocketServer: Server did fail with error: \(error)")
         #endif
-        
+
         wsserver = nil
         UUIDSockets.removeAll()
         socketsUUID.removeAll()
         remoteAddresses.removeAll()
-        
+
         let status: NSDictionary = NSDictionary(objects: ["onDidNotStart", "0.0.0.0", port!], forKeys: ["action" as NSCopying, "addr" as NSCopying, "port" as NSCopying])
         let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: status as! [AnyHashable: Any])
         pluginResult?.setKeepCallbackAs(false)
         commandDelegate?.send(pluginResult, callbackId: listenerCallbackId)
     }
-    
+
     public func server(_ server: PSWebSocketServer!, acceptWebSocketFrom address: Data, with request: URLRequest, trust: SecTrust, response: AutoreleasingUnsafeMutablePointer<HTTPURLResponse?>) -> Bool {
-        
+
         #if DEBUG
             print("WebSocketServer: Server should accept request: \(request)")
         #endif
-        
+
         if let o = origins {
             let origin = request.value(forHTTPHeaderField: "Origin")
             if o.index(of: origin!) == nil {
@@ -235,7 +251,7 @@ import Foundation
                 return false
             }
         }
-        
+
         if let _ = protocols {
             if let acceptedProtocol = getAcceptedProtocol(request) {
                 let headerFields = [ "Sec-WebSocket-Protocol" : acceptedProtocol ]
@@ -249,16 +265,16 @@ import Foundation
                 return false
             }
         }
-        
+
         return true;
     }
-    
+
     public func server(_ server: PSWebSocketServer!, webSocketDidOpen webSocket: PSWebSocket!) {
-        
+
         #if DEBUG
             print("WebSocketServer: WebSocket did open")
         #endif
-        
+
         var uuid: String!
         while uuid == nil || UUIDSockets[uuid] != nil {
             // prevent collision
@@ -266,38 +282,38 @@ import Foundation
         }
         UUIDSockets[uuid] = webSocket
         socketsUUID[webSocket] = uuid
-        
+
         var remoteAddr = ""
         if let addr = extractAddress(webSocket.remoteAddress) {
             remoteAddr = addr
             remoteAddresses[webSocket] = addr
         }
-        
+
         var acceptedProtocol = ""
         if (protocols != nil) {
             acceptedProtocol = getAcceptedProtocol(webSocket.urlRequest)!
         }
-        
+
         let httpFields = webSocket.urlRequest.allHTTPHeaderFields!
-        
+
         var resource = ""
         if (webSocket.urlRequest.url!.query != nil) {
             resource = String(cString: (webSocket.urlRequest.url!.query?.cString(using: String.Encoding.utf8))! )
         }
-        
+
         let conn: NSDictionary = NSDictionary(objects: [uuid, remoteAddr, acceptedProtocol, httpFields, resource], forKeys: ["uuid" as NSCopying, "remoteAddr" as NSCopying, "acceptedProtocol" as NSCopying, "httpFields" as NSCopying, "resource" as NSCopying])
         let status: NSDictionary = NSDictionary(objects: ["onOpen", conn], forKeys: ["action" as NSCopying, "conn" as NSCopying])
         let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: status as! [AnyHashable: Any])
         pluginResult?.setKeepCallbackAs(true)
         commandDelegate?.send(pluginResult, callbackId: listenerCallbackId)
     }
-    
+
     public func server(_ server: PSWebSocketServer!, webSocket: PSWebSocket!, didReceiveMessage message: Any) {
-        
+
         #if DEBUG
             print("WebSocketServer: Websocket did receive message: \(message)")
         #endif
-        
+
         if let uuid = socketsUUID[webSocket] {
 
             var remoteAddr = ""
@@ -317,23 +333,23 @@ import Foundation
             #endif
         }
     }
-    
+
     public func server(_ server: PSWebSocketServer!, webSocket: PSWebSocket!, didCloseWithCode code: Int, reason: String, wasClean: Bool) {
-        
+
         #if DEBUG
             print("WebSocketServer: WebSocket did close with code: \(code), reason: \(reason), wasClean: \(wasClean)")
         #endif
-        
+
         if let uuid = socketsUUID[webSocket] {
-            
+
             let remoteAddr = remoteAddresses[webSocket] // extractAddress(webSocket.remoteAddress)! bad access error
-            
+
             let conn: NSDictionary = NSDictionary(objects: [uuid, remoteAddr!], forKeys: ["uuid" as NSCopying, "remoteAddr" as NSCopying])
             let status: NSDictionary = NSDictionary(objects: ["onClose", conn, code, reason, wasClean], forKeys: ["action" as NSCopying, "conn" as NSCopying, "code" as NSCopying, "reason" as NSCopying, "wasClean" as NSCopying])
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: status as! [AnyHashable: Any])
             pluginResult?.setKeepCallbackAs(true)
             commandDelegate?.send(pluginResult, callbackId: listenerCallbackId)
-            
+
             socketsUUID.removeValue(forKey: webSocket)
             UUIDSockets.removeValue(forKey: uuid)
             remoteAddresses.removeValue(forKey: webSocket)
@@ -343,14 +359,14 @@ import Foundation
             #endif
         }
     }
-    
+
     public func server(_ server: PSWebSocketServer!, webSocket: PSWebSocket!, didFailWithError error: Error!) {
-        
+
         #if DEBUG
             print("WebSocketServer: WebSocket did fail with error: \(error)")
         #endif
     }
-    
+
     fileprivate func getAcceptedProtocol(_ request: URLRequest) -> String? {
         var acceptedProtocol: String?
         if let secWebSocketProtocol = request.value(forHTTPHeaderField: "Sec-WebSocket-Protocol") {
@@ -370,7 +386,7 @@ import Foundation
         }
         return acceptedProtocol
     }
-    
+
     fileprivate func extractAddress(_ addressBytes:Data) -> String? {
         var addr = (addressBytes as NSData).bytes.load(as: sockaddr.self)
         var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))


### PR DESCRIPTION
The rationale behind this change is that it can be useful to know not only the ip addresses of the device, but also which ip addresses correspond to which network interface.

For example, this solution can help circumvent the Android bug that does not resolve the host names on the local network, so that only the ip addresses bound to the wlan0 interface are advertised on the Zeroconf TXT record.
