### PR TITLE
exec may return onOpen right away instead of default. In this case a …

### DIFF
--- a/www/wsserver.js
+++ b/www/wsserver.js
@@ -12,7 +12,7 @@ var fail = function(o) {
     console.error("Error " + JSON.stringify(o));
 };
 
-var connections = null;
+var connections = [];
 
 var WebSocketServer = {
 


### PR DESCRIPTION
…"var connection = null" would bear in an error.