### PR TITLE
Support for Observables

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,45 @@ wsserver.getInterfaces(function(result) {
 });
 ```
 
+#### `onMessage(success, failure)`
+Add additional callback for receiving messages
+
+```javascript
+wsserver.onMessage(function(result) {
+    console.log('Connection', result.conn);
+    console.log('Message', result.msg);
+}, null); // Currently failure is not handled
+```
+
+#### `onOpen(success, failure)`
+Add additional callback for new connections 
+
+```javascript
+wsserver.onOpen(function(conn) {
+    console.log('Connection', conn);
+}, null); // Currently failure is not handled
+```
+
+#### `onClose(success, failure)`
+Add additional callback for closed connections
+
+```javascript
+wsserver.onClose(function(result) {
+    console.log('Connection', result.conn);
+    console.log(`Code: ${result.code}, Reason: ${result.reason}, Clean: ${result.wasClean}`);
+}, null); // Currently failure is not handled
+```
+
+#### `onFailure(success, failure)`
+Add additional callback for failures
+
+```javascript
+wsserver.onFailure(function(result) {
+    console.log(`Server at ${result.addr}:${result.port} has failed`);
+    console.log(result.reason);
+}, null); // Currently failure is not handled
+```
+
 ## Credits
 
 #### Android

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Binds to all available network interfaces ('0.0.0.0').
     'origins' : [ 'file://' ], // validates the 'Origin' HTTP Header.
     'protocols' : [ 'my-protocol-v1', 'my-protocol-v2' ], // validates the 'Sec-WebSocket-Protocol' HTTP Header.
     'tcpNoDelay' : true // disables Nagle's algorithm.
-}, function onStart(addr, port) {
-    console.log('Listening on %s:%d', addr, port);
+}, function onStart(server) {
+    console.log('Listening on %s:%d', server.addr, server.port);
 }, function onDidNotStart(reason) {
     console.log('Did not start. Reason: %s', reason);
 });
@@ -61,8 +61,8 @@ Binds to all available network interfaces ('0.0.0.0').
 Stops the server.
 
 ```javascript
-wsserver.stop(function onStop(addr, port) {
-    console.log('Stopped listening on %s:%d', addr, port);
+wsserver.stop(function onStop(server) {
+    console.log('Stopped listening on %s:%d', server.addr, server.port);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ wsserver.getInterfaces(function(result) {
 Add additional callback for receiving messages
 
 ```javascript
-wsserver.onMessage(function(result) {
+const uuid = wsserver.onMessage(function(result) {
     console.log('Connection', result.conn);
     console.log('Message', result.msg);
 }, null); // Currently failure is not handled
@@ -109,7 +109,7 @@ wsserver.onMessage(function(result) {
 Add additional callback for new connections 
 
 ```javascript
-wsserver.onOpen(function(conn) {
+const uuid = wsserver.onOpen(function(conn) {
     console.log('Connection', conn);
 }, null); // Currently failure is not handled
 ```
@@ -118,7 +118,7 @@ wsserver.onOpen(function(conn) {
 Add additional callback for closed connections
 
 ```javascript
-wsserver.onClose(function(result) {
+const uuid = wsserver.onClose(function(result) {
     console.log('Connection', result.conn);
     console.log(`Code: ${result.code}, Reason: ${result.reason}, Clean: ${result.wasClean}`);
 }, null); // Currently failure is not handled
@@ -128,10 +128,17 @@ wsserver.onClose(function(result) {
 Add additional callback for failures
 
 ```javascript
-wsserver.onFailure(function(result) {
+const uuid = wsserver.onFailure(function(result) {
     console.log(`Server at ${result.addr}:${result.port} has failed`);
     console.log(result.reason);
 }, null); // Currently failure is not handled
+```
+
+#### `removeCallback(uuid)`
+Remove any callback added by using uuid
+
+```javascript
+wsserver.removeCallback(uuid); // Any uuid from the on* functions
 ```
 
 ## Credits

--- a/www/wsserver.js
+++ b/www/wsserver.js
@@ -98,7 +98,10 @@ var WebSocketServer = {
             default:
                 connections = [];
                 if (success) {
-                    success(result.addr, result.port);
+                    success({
+                        addr: result.addr,
+                        port: result.port,
+                    });
                 }
             }
         }, failure, "WebSocketServer", "start", [ port, options.origins, options.protocols, options.tcpNoDelay ]);
@@ -131,7 +134,10 @@ var WebSocketServer = {
             connections = [];
             callbacks = [];
             if (success) {
-                success(result.addr, result.port);
+                success({
+                    addr: result.addr,
+                    port: result.port,
+                });
             }
         }, failure, "WebSocketServer", "stop", []);
     },

--- a/www/wsserver.js
+++ b/www/wsserver.js
@@ -1,11 +1,34 @@
 'use strict';
 var exec = require('cordova/exec');
+var utils = require('cordova/utils');
 
 var fail = function(o) {
     console.error("Error " + JSON.stringify(o));
 };
 
 var connections = [];
+var callbacks = {};
+
+function generateUniqueIdFor(obj) {
+    let id = null;
+    while (id == null || obj[id] != null) {
+        id = utils.createUUID();
+    }
+    return id;
+}
+
+function addCallback(success, failure, type) {
+    const id = generateUniqueIdFor(callbacks);
+    callbacks[id] = {success, failure, type};
+    return id;
+}
+
+function successCallback(type, result) {
+    Object.keys(callbacks)
+        .map(id => callbacks[id])
+        .filter(c => c.type === type && c.success)
+        .forEach(c => c.success(result));
+}
 
 var WebSocketServer = {
 
@@ -22,6 +45,12 @@ var WebSocketServer = {
                 if (callback) {
                     callback(result.addr, result.port, result.reason);
                 }
+
+                successCallback('failure', {
+                    addr: result.addr,
+                    port: result.port,
+                    reason: result.reason,
+                });
                 break;
             case 'onOpen':
                 var conn = result.conn;
@@ -31,6 +60,8 @@ var WebSocketServer = {
                 if (callback) {
                     callback(conn);
                 }
+
+                successCallback('open', conn);
                 break;
             case 'onMessage':
                 var conn = connections[result.uuid];
@@ -40,6 +71,11 @@ var WebSocketServer = {
                         callback(conn, result.msg);
                     }
                 }
+
+                successCallback('message', {
+                    conn: conn,
+                    msg: result.msg,
+                });
                 break;
             case 'onClose':
                 var conn = connections[result.uuid];
@@ -50,6 +86,13 @@ var WebSocketServer = {
                     if (callback) {
                         callback(conn, result.code, result.reason, result.wasClean);
                     }
+
+                    successCallback('close', {
+                        conn: conn,
+                        code: result.code,
+                        reason: result.reason,
+                        wasClean: result.wasClean,
+                    });
                 }
                 break;
             default:
@@ -61,9 +104,32 @@ var WebSocketServer = {
         }, failure, "WebSocketServer", "start", [ port, options.origins, options.protocols, options.tcpNoDelay ]);
     },
 
+    onMessage: function(success, failure) {
+        return addCallback(success, failure, 'message');
+    },
+
+    onOpen: function(success, failure) {
+        return addCallback(success, failure, 'open');
+    },
+
+    onClose: function(success, failure) {
+        return addCallback(success, failure, 'close');
+    },
+
+    onFailure: function(success, failure) {
+        return addCallback(success, failure, 'failure');
+    },
+
+    removeCallback: function(uuid) {
+        if (uuid && callbacks[uuid]) {
+            delete callbacks[uuid];
+        }
+    },
+
     stop : function(success, failure) {
         return exec(function(result) {
             connections = [];
+            callbacks = [];
             if (success) {
                 success(result.addr, result.port);
             }


### PR DESCRIPTION
For Issue #63 

I managed to change it without touching any backend code. It should keep all the other functionalities the same, except the start and stop functions now return a single object.
The workaround for promises that you mentioned did not really work. It just splited the address string "0.0.0.0" to "0" and "."